### PR TITLE
Resolve import aliases

### DIFF
--- a/pydantic2zod/_compiler.py
+++ b/pydantic2zod/_compiler.py
@@ -163,11 +163,12 @@ def _class_field_type_to_zod(field_type: PyType, code: "Lines") -> None:
                     code.add(", ", inline=True)
             code.add(")", inline=True)
 
-        case UserDefinedType(name=type_):
-            if type_ == "UUID":
+        case UserDefinedType(name=type_name):
+            if type_name == "uuid.UUID":
                 code.add("z.string().uuid()", inline=True)
             else:
-                code.add(type_, inline=True)
+                type_name = type_name.split(".")[-1]
+                code.add(type_name, inline=True)
 
         case other:
             assert False, f"Unsupported field type: '{other}'"

--- a/pydantic2zod/_model.py
+++ b/pydantic2zod/_model.py
@@ -18,6 +18,18 @@ class PyValue:
 
 
 @dataclass
+class Import:
+    from_module: str
+    "pkg.module1"
+
+    name: str
+    "ClassName"
+
+    alias: str | None = None
+    """`import module.Class as OtherClass`"""
+
+
+@dataclass
 class ClassField:
     name: str
     type: PyType

--- a/pydantic2zod/_model.py
+++ b/pydantic2zod/_model.py
@@ -28,6 +28,8 @@ class ClassField:
 @dataclass
 class ClassDecl:
     name: str
+    full_path: str = ""
+    """pkg1.module.ClassName"""
     fields: list[ClassField] = field(default_factory=lambda: [])
     base_classes: list[str] = field(default_factory=lambda: [])
     comment: str | None = None

--- a/pydantic2zod/_parser.py
+++ b/pydantic2zod/_parser.py
@@ -131,8 +131,7 @@ class _ParseModule(_Parse[cst.Module]):
 
         self._class_nodes[cls.name] = node
         self._classes[cls.name] = cls
-        if cls.name in self._model_graph:
-            _logger.warning("Model with name '%s' already exists.", cls.name)
+        # TODO(povilas): add_node(cls.full_path) - http.cassette.Request
         self._model_graph.add_node(cls.name)
 
     @m.call_if_inside(

--- a/pydantic2zod/_parser.py
+++ b/pydantic2zod/_parser.py
@@ -261,7 +261,7 @@ class _ParseClassDecl(_Parse[cst.ClassDef]):
         )
 
 
-class _ParseImportFrom(_Parse):
+class _ParseImportFrom(_Parse[cst.ImportFrom]):
     def __init__(self) -> None:
         super().__init__()
         self._from = list[str]()

--- a/tests/fixtures/builtin_types.py
+++ b/tests/fixtures/builtin_types.py
@@ -1,0 +1,8 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    id: UUID
+    name: str

--- a/tests/fixtures/import_alias.py
+++ b/tests/fixtures/import_alias.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from .all_in_one import Class as Cls
+
+
+class Module(BaseModel):
+    name: str
+    classes: list[Cls]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -218,3 +218,28 @@ class TestParseModule:
         ]
         # built-in types are not considered external models
         assert parse.external_models() == set()
+
+    def test_resolves_import_aliases(self):
+        parse = _ParseModule(
+            import_module("tests.fixtures.import_alias"), DiGraph()
+        ).exec()
+
+        assert parse.classes() == [
+            ClassDecl(
+                name="Module",
+                full_path="tests.fixtures.import_alias.Module",
+                fields=[
+                    ClassField(name="name", type=PrimitiveType(name="str")),
+                    ClassField(
+                        name="classes",
+                        type=GenericType(
+                            generic="list",
+                            type_vars=[UserDefinedType(name="Cls")],
+                        ),
+                    ),
+                ],
+                base_classes=["BaseModel"],
+            )
+        ]
+        # built-in types are not considered external models
+        assert parse.external_models() == set(["tests.fixtures.all_in_one.Class"])

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -23,6 +23,7 @@ def test_recurses_into_imported_modules():
     assert classes == [
         ClassDecl(
             name="Class",
+            full_path="tests.fixtures.all_in_one.Class",
             fields=[
                 ClassField(name="name", type=PrimitiveType(name="str")),
                 ClassField(
@@ -36,11 +37,13 @@ def test_recurses_into_imported_modules():
         ),
         ClassDecl(
             name="DataClass",
+            full_path="tests.fixtures.all_in_one.DataClass",
             fields=[ClassField(name="frozen", type=PrimitiveType(name="bool"))],
             base_classes=["Class"],
         ),
         ClassDecl(
             name="Module",
+            full_path="tests.fixtures.external.Module",
             fields=[
                 ClassField(name="name", type=PrimitiveType(name="str")),
                 ClassField(
@@ -70,6 +73,7 @@ class TestParseModule:
         assert classes == [
             ClassDecl(
                 name="Class",
+                full_path="tests.fixtures.all_in_one.Class",
                 base_classes=["BaseModel"],
                 fields=[
                     ClassField(name="name", type=PrimitiveType(name="str")),
@@ -83,6 +87,7 @@ class TestParseModule:
             ),
             ClassDecl(
                 name="DataClass",
+                full_path="tests.fixtures.all_in_one.DataClass",
                 base_classes=["Class"],
                 fields=[
                     ClassField(name="frozen", type=PrimitiveType(name="bool")),
@@ -90,6 +95,7 @@ class TestParseModule:
             ),
             ClassDecl(
                 name="Module",
+                full_path="tests.fixtures.all_in_one.Module",
                 base_classes=["BaseModel"],
                 fields=[
                     ClassField(name="name", type=PrimitiveType(name="str")),
@@ -114,8 +120,7 @@ class TestParseModule:
             .classes()
         )
 
-        assert len(classes) == 1
-        assert classes[0].name == "Class"
+        assert set(c.name for c in classes) == {"Class"}
 
     def test_parses_only_the_models_explicitly_asked_and_their_dependencies(self):
         classes = (
@@ -128,9 +133,7 @@ class TestParseModule:
             .classes()
         )
 
-        assert len(classes) == 2
-        assert classes[0].name == "Class"
-        assert classes[1].name == "Module"
+        assert set(c.name for c in classes) == {"Class", "Module"}
 
     def test_detects_external_models(self):
         parse = _ParseModule(import_module("tests.fixtures.external"), DiGraph()).exec()
@@ -139,6 +142,7 @@ class TestParseModule:
         assert parse.classes() == [
             ClassDecl(
                 name="Module",
+                full_path="tests.fixtures.external.Module",
                 base_classes=["BaseModel"],
                 fields=[
                     ClassField(name="name", type=PrimitiveType(name="str")),
@@ -161,11 +165,13 @@ class TestParseModule:
         assert parse.classes() == [
             ClassDecl(
                 name="Function",
+                full_path="tests.fixtures.type_alias.Function",
                 fields=[ClassField(name="name", type=PrimitiveType(name="str"))],
                 base_classes=["BaseModel"],
             ),
             ClassDecl(
                 name="LambdaFunc",
+                full_path="tests.fixtures.type_alias.LambdaFunc",
                 fields=[
                     ClassField(
                         name="args",
@@ -178,6 +184,7 @@ class TestParseModule:
             ),
             ClassDecl(
                 name="EventBus",
+                full_path="tests.fixtures.type_alias.EventBus",
                 fields=[
                     ClassField(
                         name="handlers",
@@ -201,6 +208,7 @@ class TestParseModule:
         assert parse.classes() == [
             ClassDecl(
                 name="User",
+                full_path="tests.fixtures.builtin_types.User",
                 fields=[
                     ClassField(name="id", type=UserDefinedType(name="UUID")),
                     ClassField(name="name", type=PrimitiveType(name="str")),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -190,3 +190,21 @@ class TestParseModule:
                 base_classes=["BaseModel"],
             ),
         ]
+
+    def test_supports_builtin_types(self):
+        parse = _ParseModule(DiGraph()).visit(
+            _parse_file("tests/fixtures/builtin_types.py")
+        )
+
+        assert parse.classes() == [
+            ClassDecl(
+                name="User",
+                fields=[
+                    ClassField(name="id", type=UserDefinedType(name="UUID")),
+                    ClassField(name="name", type=PrimitiveType(name="str")),
+                ],
+                base_classes=["BaseModel"],
+            )
+        ]
+        # built-in types are not considered external models
+        assert parse.external_models() == {}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -49,7 +49,10 @@ def test_recurses_into_imported_modules():
                 ClassField(
                     name="classes",
                     type=GenericType(
-                        generic="list", type_vars=[UserDefinedType(name="DataClass")]
+                        generic="list",
+                        type_vars=[
+                            UserDefinedType(name="tests.fixtures.all_in_one.DataClass")
+                        ],
                     ),
                 ),
             ],
@@ -150,7 +153,11 @@ class TestParseModule:
                         name="classes",
                         type=GenericType(
                             generic="list",
-                            type_vars=[UserDefinedType(name="DataClass")],
+                            type_vars=[
+                                UserDefinedType(
+                                    name="tests.fixtures.all_in_one.DataClass"
+                                )
+                            ],
                         ),
                     ),
                 ],
@@ -210,7 +217,7 @@ class TestParseModule:
                 name="User",
                 full_path="tests.fixtures.builtin_types.User",
                 fields=[
-                    ClassField(name="id", type=UserDefinedType(name="UUID")),
+                    ClassField(name="id", type=UserDefinedType(name="uuid.UUID")),
                     ClassField(name="name", type=PrimitiveType(name="str")),
                 ],
                 base_classes=["BaseModel"],
@@ -234,7 +241,9 @@ class TestParseModule:
                         name="classes",
                         type=GenericType(
                             generic="list",
-                            type_vars=[UserDefinedType(name="Cls")],
+                            type_vars=[
+                                UserDefinedType(name="tests.fixtures.all_in_one.Class")
+                            ],
                         ),
                     ),
                 ],


### PR DESCRIPTION
Now `pydantic2zod` is capable of resolving aliases and recursing into dependent modules respectively:
```py
from pydantic import BaseModel

from .all_in_one import Class as Cls


class Module(BaseModel):
    name: str
    classes: list[Cls]
```