### PR TITLE
Fix type alias resolution when parsing types recursively

### DIFF
--- a/pydantic2zod/_parser.py
+++ b/pydantic2zod/_parser.py
@@ -173,20 +173,13 @@ class _ParseModule(_Parse[cst.Module]):
             for field in cls.fields:
                 self._resolve_class_field_names(field.type)
 
-            # Try to resolve type aliases and generic type variables.
-            for f in cls.fields:
-                # TODO(povilas): recurse into generic types
-                if isinstance(f.type, UserDefinedType):
-                    if node := self._alias_nodes.get(f.type.name):
-                        assert node.value
-                        f.type = _extract_type(node.value)
-
-                    elif (
-                        f.type.name in cls.type_vars
-                        or f.type.name in self._ignore_types
+                if isinstance(field.type, UserDefinedType):
+                    if (
+                        field.type.name in self._ignore_types
+                        or field.type.name in cls.type_vars
                     ):
                         # Yet to learn know how to parse generic type variables.
-                        f.type = AnyType()
+                        field.type = AnyType()
 
     def _recursively_parse_pydantic_model(self, cls: ClassDecl) -> None:
         if not self._is_pydantic_model(cls) or cls.name in self._pydantic_classes:
@@ -288,6 +281,15 @@ class _ParseModule(_Parse[cst.Module]):
         cls.full_path = cls_decl.full_path
         self._model_graph.add_node(cls.full_path)
         self._pydantic_classes[cls.name] = cls
+
+        # Try to resolve type aliases and generic type variables.
+        for f in cls.fields:
+            # TODO(povilas): recurse into generic types
+            if isinstance(f.type, UserDefinedType):
+                if node := self._alias_nodes.get(f.type.name):
+                    assert node.value
+                    f.type = _extract_type(node.value)
+
         return cls
 
     def _is_pydantic_model(self, cls: ClassDecl) -> bool:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -206,8 +206,12 @@ class TestParseModule:
                         name="handlers",
                         type=UnionType(
                             types=[
-                                UserDefinedType(name="Function"),
-                                UserDefinedType(name="LambdaFunc"),
+                                UserDefinedType(
+                                    name="tests.fixtures.type_alias.Function"
+                                ),
+                                UserDefinedType(
+                                    name="tests.fixtures.type_alias.LambdaFunc"
+                                ),
                             ]
                         ),
                     )


### PR DESCRIPTION
Aliases must be resolved before `leave_Module()` is called. Otherwise type dependencies will not be detected properly when an alias is in a recursed module.