### PR TITLE
Run QA on pydantic v1 and v2

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        pydantic_versions: ["< 2", ">= 2"]
         task:
         - check_types
         - check_fmt
@@ -27,7 +28,9 @@ jobs:
         poetry-version: "1.3.2"
 
     - name: Install dependencies
-      run: poetry install
+      run: |
+        poetry install
+        poetry run pip install "pydantic ${{ matrix['pydantic_versions'] }}"
 
     - name: QA
       run: poetry run task ${{ matrix['task'] }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Transfer your type safe Python data models to TypeScript:
 
 * Retains the class and field names, comments.
 * Customize the output, etc.
+* Suports both **pydantic** v1 and v2.
 
 ![example](example.gif)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -848,4 +848,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "bad45cb0fbadb0084a703ae21e6db88f5b278141f5b22ca14cb21dc6a8466eeb"
+content-hash = "10f7270e0b55f8ebde937ddfe09d118f6e24871801491348a3a3437316b78c88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pytest-clarity = "^1.0.1"
 pytest-cov = "^4.0.0"
 taskipy = "^1.12.0"
 black = "^23.10.1"
-pydantic = "^2.4.2"
+pydantic = ">=1.10, <3"
 snapshottest = "^0.6.0"
 
 [build-system]


### PR DESCRIPTION
Already both of the **pydantic** versions are supported.
To make sure we don't digress, the QA checks will be run with both pydantic versions.