### PR TITLE
Fix type definition that typer chokes on

### DIFF
--- a/pydantic2zod/__main__.py
+++ b/pydantic2zod/__main__.py
@@ -15,6 +15,7 @@ Compilation is a 2 step process:
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 import rich
 import typer
@@ -27,7 +28,7 @@ _logger = logging.getLogger(__name__)
 
 def main(
     file: str,
-    out_to: str | None = None,
+    out_to: Optional[str],
     silent: bool = typer.Option(
         False, "-s", "--silent", help="If true, don't print the logs."
     ),


### PR DESCRIPTION
`typer` has a longstanding issue around accepting the syntax `str | None`, see https://github.com/tiangolo/typer/issues/533 and many related issues. 

It seems easier not to use that syntax at all.

Apologies if this is incorrect Python, I don't speak it very well, but it was enough to unblock me :smile: